### PR TITLE
chore(docs): fixed menu Github link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,7 @@ module.exports = {
         },
         {to: 'blog', label: 'Blog', position: 'left'},
         {
-          href: 'https://https://github.com/AndreasFaust/react-raster',
+          href: 'https://github.com/AndreasFaust/react-raster',
           label: 'GitHub',
           position: 'right',
         },


### PR DESCRIPTION
There was an extra https in Github menu link.